### PR TITLE
Add example menu for jobs/gang in server.mdx

### DIFF
--- a/docs/resources/qbx_management/exports/server.mdx
+++ b/docs/resources/qbx_management/exports/server.mdx
@@ -28,3 +28,14 @@ exports.qbx_management:RegisterBossMenu(menuInfo)
     - Default: `vec3(1.5, 1.5, 1.5)`
   - rotation?: `number`
     - Default: `0.0`
+```
+example menu 
+
+            ambulance = {
+                coords = vec3(310.87, -597.55, 43.28), -- Replace with exact Hospital coords
+                size = vec3(1.5, 1.5, 1.5),
+                rotation = 0.0,
+                type = 'job',
+            },
+
+```


### PR DESCRIPTION
### Summary

Added a simple example menu for **jobs/gang configuration** to make setup easier and provide a quick reference for users.

### Notes

This is only an example implementation to
